### PR TITLE
Fix synthetic repo creation to be deterministic

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,7 +119,7 @@ payloads:
     path: payloads/directory/edge_cases/unicode_normalization/
   git:
   - description: Synthetic Git repo with main, feature, and a tag
-    expected_swhid: swh:1:snp:8cd1b580ad6f983730e983e33ef6bad3f3fc0c67
+    expected_swhid: swh:1:snp:d66db619f7d82b4bc6524810d045d731ae099ef7
     name: synthetic_repo
     path: payloads/git/synthetic/
   - description: Git repo with snapshot branches in alphabetical order (alpha, beta, gamma, zeta) - tests branch ordering


### PR DESCRIPTION
The synthetic_repo test was failing because commits had non-deterministic hashes despite fixed timestamps. Two issues were causing this:

1. All commits used the same timestamp instead of incrementing between commits
2. User's global commit.gpgSign config was adding gpgsig headers to commits, making them non-reproducible

Fixed by:
- Using incremental timestamps (base + 60s per commit) following Git's test suite pattern
- Disabling commit.gpgSign in addition to tag.gpgSign
- Changing timestamp format from ISO 8601 to Unix timestamp + timezone